### PR TITLE
Cursor direction is saved when selecting text

### DIFF
--- a/Direction.ts
+++ b/Direction.ts
@@ -1,0 +1,1 @@
+export type Direction = "forward" | "backward" | "none"

--- a/Handler/text.spec.ts
+++ b/Handler/text.spec.ts
@@ -1,0 +1,181 @@
+import { Action } from "../Action"
+import { Formatter } from "../Formatter"
+import { get } from "./index"
+
+describe("text", () => {
+	const handler = get("text") as Formatter
+	it("Enter character", () => {
+		const result = Action.apply(handler, { value: "", selection: { start: 0, end: 0 } }, { key: "a" })
+		expect(result).toMatchObject({ value: "a", selection: { start: 1, end: 1 } })
+	})
+	it("Move left", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 10, end: 10 } },
+			{ key: "ArrowLeft" }
+		)
+		expect(result).toMatchObject({ value: "This is a sentence", selection: { start: 9, end: 9 } })
+	})
+	it("Shift Move Left", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 10, end: 10, direction: "backward" } },
+			{ key: "ArrowLeft", shiftKey: true }
+		)
+		expect(result).toMatchObject({
+			value: "This is a sentence",
+			selection: { start: 9, end: 10, direction: "backward" },
+		})
+	})
+	it("Shift Move Left with Selection", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 10, end: 11, direction: "backward" } },
+			{ key: "ArrowLeft", shiftKey: true }
+		)
+		expect(result).toMatchObject({
+			value: "This is a sentence",
+			selection: { start: 9, end: 11, direction: "backward" },
+		})
+	})
+	it("Move Right", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 10, end: 10 } },
+			{ key: "ArrowRight" }
+		)
+		expect(result).toMatchObject({ value: "This is a sentence", selection: { start: 11, end: 11 } })
+	})
+	it("Shift Move Right", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 10, end: 10 } },
+			{ key: "ArrowRight", shiftKey: true }
+		)
+		expect(result).toMatchObject({
+			value: "This is a sentence",
+			selection: { start: 10, end: 11, direction: "forward" },
+		})
+	})
+	it("Shift Move Right with Selection", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 10, end: 11, direction: "forward" } },
+			{ key: "ArrowRight", shiftKey: true }
+		)
+		expect(result).toMatchObject({
+			value: "This is a sentence",
+			selection: { start: 10, end: 12, direction: "forward" },
+		})
+	})
+	it("Home", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 10, end: 10, direction: "forward" } },
+			{ key: "Home" }
+		)
+		expect(result).toMatchObject({
+			value: "This is a sentence",
+			selection: { start: 0, end: 0 },
+		})
+	})
+	it("Shift Home", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 10, end: 10, direction: "forward" } },
+			{ key: "Home", shiftKey: true }
+		)
+		expect(result).toMatchObject({
+			value: "This is a sentence",
+			selection: { start: 0, end: 10, direction: "backward" },
+		})
+	})
+	it("Shift Home with selection", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 10, end: 15, direction: "forward" } },
+			{ key: "Home", shiftKey: true }
+		)
+		expect(result).toMatchObject({
+			value: "This is a sentence",
+			selection: { start: 0, end: 10, direction: "backward" },
+		})
+	})
+	it("End", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 10, end: 10, direction: "forward" } },
+			{ key: "End" }
+		)
+		expect(result).toMatchObject({
+			value: "This is a sentence",
+			selection: { start: 18, end: 18 },
+		})
+	})
+	it("Shift End", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 10, end: 10, direction: "forward" } },
+			{ key: "End", shiftKey: true }
+		)
+		expect(result).toMatchObject({
+			value: "This is a sentence",
+			selection: { start: 10, end: 18, direction: "forward" },
+		})
+	})
+	it("Shift End with selection", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 10, end: 15, direction: "backward" } },
+			{ key: "End", shiftKey: true }
+		)
+		expect(result).toMatchObject({
+			value: "This is a sentence",
+			selection: { start: 15, end: 18, direction: "forward" },
+		})
+	})
+	it("Backspace", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 4, end: 4 } },
+			{ key: "Backspace" }
+		)
+		expect(result).toMatchObject({
+			value: "Thi is a sentence",
+			selection: { start: 3, end: 3 },
+		})
+	})
+	it("Backspace with selection", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 4, end: 9, direction: "backward" } },
+			{ key: "Backspace" }
+		)
+		expect(result).toMatchObject({
+			value: "This sentence",
+			selection: { start: 4, end: 4 },
+		})
+	})
+	it("Delete", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 4, end: 4, direction: "backward" } },
+			{ key: "Delete" }
+		)
+		expect(result).toMatchObject({
+			value: "Thisis a sentence",
+			selection: { start: 4, end: 4 },
+		})
+	})
+	it("Delete with selection", () => {
+		const result = Action.apply(
+			handler,
+			{ value: "This is a sentence", selection: { start: 4, end: 9, direction: "backward" } },
+			{ key: "Delete" }
+		)
+		expect(result).toMatchObject({
+			value: "This sentence",
+			selection: { start: 4, end: 4 },
+		})
+	})
+})

--- a/Selection.ts
+++ b/Selection.ts
@@ -1,4 +1,6 @@
+import { Direction } from "./Direction"
 export interface Selection {
 	start: number
 	end: number
+	direction?: Direction
 }

--- a/State.ts
+++ b/State.ts
@@ -6,6 +6,9 @@ export interface State {
 }
 export namespace State {
 	export function copy(state: Readonly<State>): State {
-		return { value: state.value, selection: { start: state.selection.start, end: state.selection.end } }
+		return {
+			value: state.value,
+			selection: { start: state.selection.start, end: state.selection.end, direction: state.selection.direction },
+		}
 	}
 }

--- a/StateEditor.ts
+++ b/StateEditor.ts
@@ -6,7 +6,7 @@ export class StateEditor implements Readonly<State> {
 	readonly selection: Readonly<Selection>
 	private constructor(state: Readonly<State>) {
 		this.value = state.value
-		this.selection = { start: state.selection.start, end: state.selection.end }
+		this.selection = { start: state.selection.start, end: state.selection.end, direction: state.selection.direction }
 	}
 
 	get(index: number, length = 1): string {
@@ -33,7 +33,10 @@ export class StateEditor implements Readonly<State> {
 			while ((s = result.value.search(start)) > -1)
 				result = result.replace(s, s + start.length, end)
 		} else if (typeof start == "number" && typeof end == "number") {
-			const state = { value: this.value, selection: { start: this.selection.start, end: this.selection.end } }
+			const state = {
+				value: this.value,
+				selection: { start: this.selection.start, end: this.selection.end, direction: this.selection.direction },
+			}
 			if (!value)
 				value = ""
 			state.value = this.value.slice(0, start) + value + this.value.slice(end, this.value.length)

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import { Action } from "./Action"
 import { Converter } from "./Converter"
+import { Direction } from "./Direction"
 import { Formatter } from "./Formatter"
 import { format, get, parse } from "./Handler"
 import { Selection } from "./Selection"
@@ -8,4 +9,4 @@ import { State } from "./State"
 import { StateEditor } from "./StateEditor"
 import { Type } from "./Type"
 
-export { Action, Converter, Formatter, Selection, Settings, State, StateEditor, Type, get, format, parse }
+export { Action, Converter, Direction, Formatter, Selection, Settings, State, StateEditor, Type, get, format, parse }


### PR DESCRIPTION
Save `direction` (`forward`, `backward`, `none`) in `Selection` type.
When using `ShiftKey` + `ArrowLeft`/`ArrowRight`/`Home`/`End` direction will be preserved.