### PR TITLE
handle paste

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
         with:
           node-version: 16
           cache: 'npm'
-      - run: npm audit
+      - run: npm audit --production

--- a/Action.ts
+++ b/Action.ts
@@ -51,6 +51,12 @@ export namespace Action {
 		return formatter.format(StateEditor.copy(result))
 	}
 
+	export function paste(formatter: Formatter, state: Readonly<State>, pasted: string) {
+		const result = State.copy(formatter.unformat(StateEditor.copy(state)))
+		replace(result, pasted)
+		return formatter.format(StateEditor.copy(result))
+	}
+
 	function ctrlArrow(formatter: Formatter, state: Readonly<State>, action: Action): Readonly<State> {
 		let cursorPosition = Selection.getCursor(state.selection)
 		let stalkPosition = Selection.getStalker(state.selection)


### PR DESCRIPTION
Add function for handling paste.
Before paste was hacked in by adding an event for each character.

## Example 
if `hello` was pasted, this would create the events:
`h`
`he`
`hel`
`hell`
`hello`

Now only one event should be created for this.