### PR TITLE
fix: various duration fixes

### DIFF
--- a/Handler/duration.spec.ts
+++ b/Handler/duration.spec.ts
@@ -1,9 +1,9 @@
 import { Action } from "../Action"
-import { Formatter } from "../Formatter"
 import { get } from "./index"
 
 describe("duration", () => {
-	const handler = get("duration") as Formatter
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+	const handler = get<{ hours?: number; minutes?: number }>("duration")!
 	it("Key event first key 1", () => {
 		const result = Action.apply(handler, { value: "", selection: { start: 0, end: 0 } }, { key: "1" })
 		expect(result).toMatchObject({ value: "1 h", selection: { start: 1, end: 1 } })
@@ -33,5 +33,26 @@ describe("duration", () => {
 		let result = { value: "", selection: { start: 0, end: 0 } }
 		result = Action.apply(handler, result, { key: "f" })
 		expect(result).toMatchObject({ value: "", selection: { start: 0, end: 0 } })
+	})
+	it("starting with :", () => {
+		let result = { value: "", selection: { start: 1, end: 1 } }
+		result = Action.apply(handler, result, { key: ":" })
+		expect(result).toMatchObject({ value: "0: h", selection: { start: 3, end: 3 } })
+	})
+	it("toString", () => {
+		expect(handler.toString({})).toEqual("0:00")
+		expect(handler.toString({ hours: 25 })).toEqual("25:00")
+		expect(handler.toString({ minutes: 30 })).toEqual("0:30")
+		expect(handler.toString({ minutes: 3 })).toEqual("0:03")
+		expect(handler.toString({ hours: 8, minutes: 5 })).toEqual("8:05")
+	})
+	it("fromString", () => {
+		expect(handler.fromString("0:0")).toEqual({ hours: 0, minutes: 0 })
+		expect(handler.fromString("")).toEqual({ hours: 0, minutes: 0 })
+		expect(handler.fromString(":")).toEqual({ hours: 0, minutes: 0 })
+		expect(handler.fromString(":0")).toEqual({ hours: 0, minutes: 0 })
+		expect(handler.fromString("0")).toEqual({ hours: 0, minutes: 0 })
+		expect(handler.fromString("3:30")).toEqual({ hours: 3, minutes: 30 })
+		expect(handler.fromString("3:3")).toEqual({ hours: 3, minutes: 3 })
 	})
 })

--- a/Handler/duration.ts
+++ b/Handler/duration.ts
@@ -5,33 +5,43 @@ import { State } from "../State"
 import { StateEditor } from "../StateEditor"
 import { add } from "./base"
 
-function toDuration(hours: number): { hours: number; minutes: number } {
-	const h = Math.floor(hours)
-	return { hours: h, minutes: Math.floor((hours - h) * 60) }
-}
-
-class Handler implements Converter<{ hours: number; minutes: number }>, Formatter {
-	toString(data: number | string | any): string {
-		const duration = typeof data == "number" && toDuration(data)
-		return duration ? duration.hours.toString() + ":" + duration.minutes.toString().padStart(2, "0") : ""
+class Handler implements Converter<{ hours?: number; minutes?: number } | undefined>, Formatter {
+	private pattern: RegExp
+	constructor(readonly unit = "h") {
+		this.unit = ` ${unit.trim()}`
+		const suffix = this.unit
+			.split("")
+			.map(symbol => symbol + "{0,1}")
+			.join("")
+		this.pattern = new RegExp(`^\\d*:{0,1}[0-5]{0,1}[0-9]{0,1}${suffix}$`)
 	}
-	fromString(value: string): { hours: number; minutes: number } | undefined {
+	toString(data: { hours?: number; minutes?: number } | undefined): string {
+		return `${data?.hours?.toString(10) ?? "0"}:${data?.minutes?.toString(10).padStart(2, "0") ?? "00"}`
+	}
+	fromString(value: string): { hours?: number; minutes?: number } | undefined {
 		const splitted = typeof value == "string" && value.split(":", 2).map(value => Number.parseInt(value))
-		return splitted ? { hours: splitted[0], minutes: splitted[1] } : undefined
+		return splitted
+			? {
+					...(Number.isFinite(splitted[0]) && { hours: splitted[0] }),
+					...(Number.isFinite(splitted[1]) && { minutes: splitted[1] }),
+			  }
+			: undefined
 	}
 	format(unformatted: StateEditor): Readonly<State> & Settings {
 		let result = unformatted
+		if (result.value.match(/^:/))
+			result = result.prepend("0")
 		if (result.value.length > 0)
-			result = result.suffix(" h")
+			result = result.suffix(this.unit)
 		return { ...result, type: "tel", pattern: /^\d*:{0,1}[0-5]{0,1}[0-9]{0,1}(\sh{0,1}){0,1}$/ }
 	}
 	unformat(formatted: StateEditor): Readonly<State> {
-		return formatted.delete(" h")
+		return formatted.delete(this.unit)
 	}
 	allowed(symbol: string, state: Readonly<State>): boolean {
-		const nextValue = state.value.slice(0, state.selection.start) + symbol + state.value.slice(state.selection.end)
-		const matchResult = nextValue.match(/^\d*:{0,1}[0-5]{0,1}[0-9]{0,1}(\sh{0,1}){0,1}$/)
-		return matchResult !== null
+		const nextValue =
+			state.value.slice(0, state.selection.start) + symbol + state.value.slice(state.selection.end) + this.unit
+		return !!nextValue.match(this.pattern)
 	}
 }
 add("duration", () => new Handler())

--- a/Handler/duration.ts
+++ b/Handler/duration.ts
@@ -5,7 +5,7 @@ import { State } from "../State"
 import { StateEditor } from "../StateEditor"
 import { add } from "./base"
 
-class Handler implements Converter<{ hours?: number; minutes?: number } | undefined>, Formatter {
+class Handler implements Converter<{ hours: number; minutes: number } | undefined>, Formatter {
 	private pattern: RegExp
 	constructor(readonly unit = "h") {
 		this.unit = ` ${unit.trim()}`
@@ -15,15 +15,15 @@ class Handler implements Converter<{ hours?: number; minutes?: number } | undefi
 			.join("")
 		this.pattern = new RegExp(`^\\d*:{0,1}[0-5]{0,1}[0-9]{0,1}${suffix}$`)
 	}
-	toString(data: { hours?: number; minutes?: number } | undefined): string {
+	toString(data: { hours: number; minutes: number } | undefined): string {
 		return `${data?.hours?.toString(10) ?? "0"}:${data?.minutes?.toString(10).padStart(2, "0") ?? "00"}`
 	}
-	fromString(value: string): { hours?: number; minutes?: number } | undefined {
+	fromString(value: string): { hours: number; minutes: number } | undefined {
 		const splitted = typeof value == "string" && value.split(":", 2).map(value => Number.parseInt(value))
 		return splitted
 			? {
-					...(Number.isFinite(splitted[0]) && { hours: splitted[0] }),
-					...(Number.isFinite(splitted[1]) && { minutes: splitted[1] }),
+					hours: !splitted[0] || !Number.isFinite(splitted[0]) ? 0 : splitted[0],
+					minutes: !splitted[1] || !Number.isFinite(splitted[1]) ? 0 : splitted[1],
 			  }
 			: undefined
 	}

--- a/Handler/duration.ts
+++ b/Handler/duration.ts
@@ -44,4 +44,4 @@ class Handler implements Converter<{ hours?: number; minutes?: number } | undefi
 		return !!nextValue.match(this.pattern)
 	}
 }
-add("duration", () => new Handler())
+add("duration", (argument: any[]) => new Handler(...argument))


### PR DESCRIPTION
* if hour/minute property is set to 0 if they are parsed to `NaN` or `undefined`
* prepend formatted string with `"0"` if it starts with `":"`
* unit can be changed from `"h"` to anything else
* no longer accepts the input `" "` or `"h"` at the end of the input
* `toString()` parses input string correctly