### PR TITLE
fix: format() function spreads arguments to get

### DIFF
--- a/Handler/base.ts
+++ b/Handler/base.ts
@@ -42,7 +42,7 @@ export function format(
 export function format(data: number, type: "price", currency: isoly.Currency): string
 export function format(data: any, type: Type, ...argument: any[]): string
 export function format(data: any, type: Type, ...argument: any[]): string {
-	const handler = get(type, argument)
+	const handler = get(type, ...argument)
 	return handler
 		? handler.format(StateEditor.modify(handler.toString(typeof data == "string" ? parse(data, type, argument) : data)))
 				.value

--- a/Handler/duration.spec.ts
+++ b/Handler/duration.spec.ts
@@ -1,9 +1,13 @@
 import { Action } from "../Action"
-import { get } from "./index"
+import { format, get } from "./index"
 
 describe("duration", () => {
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	const handler = get<{ hours?: number; minutes?: number }>("duration")!
+	const handler = get<{ hours?: number; minutes?: number }>("duration", " h")!
+	it("format", () => {
+		expect(format({ hours: 1, minutes: 30 }, "duration", "h")).toEqual("1:30h")
+		expect(format({ hours: 1, minutes: 30 }, "duration", "")).toEqual("1:30")
+	})
 	it("Key event first key 1", () => {
 		const result = Action.apply(handler, { value: "", selection: { start: 0, end: 0 } }, { key: "1" })
 		expect(result).toMatchObject({ value: "1 h", selection: { start: 1, end: 1 } })

--- a/Handler/duration.ts
+++ b/Handler/duration.ts
@@ -7,13 +7,12 @@ import { add } from "./base"
 
 class Handler implements Converter<{ hours: number; minutes: number } | undefined>, Formatter {
 	private pattern: RegExp
-	constructor(readonly unit = "h") {
-		this.unit = ` ${unit.trim()}`
-		const suffix = this.unit
+	constructor(readonly suffix: string = "h") {
+		const pattern = this.suffix
 			.split("")
 			.map(symbol => symbol + "{0,1}")
 			.join("")
-		this.pattern = new RegExp(`^\\d*:{0,1}[0-5]{0,1}[0-9]{0,1}${suffix}$`)
+		this.pattern = new RegExp(`^\\d*:{0,1}[0-5]{0,1}[0-9]{0,1}${pattern}$`)
 	}
 	toString(data: { hours: number; minutes: number } | undefined): string {
 		return `${data?.hours?.toString(10) ?? "0"}:${data?.minutes?.toString(10).padStart(2, "0") ?? "00"}`
@@ -32,15 +31,15 @@ class Handler implements Converter<{ hours: number; minutes: number } | undefine
 		if (result.value.match(/^:/))
 			result = result.prepend("0")
 		if (result.value.length > 0)
-			result = result.suffix(this.unit)
+			result = result.suffix(this.suffix)
 		return { ...result, type: "tel", pattern: /^\d*:{0,1}[0-5]{0,1}[0-9]{0,1}(\sh{0,1}){0,1}$/ }
 	}
 	unformat(formatted: StateEditor): Readonly<State> {
-		return formatted.delete(this.unit)
+		return formatted.delete(this.suffix)
 	}
 	allowed(symbol: string, state: Readonly<State>): boolean {
 		const nextValue =
-			state.value.slice(0, state.selection.start) + symbol + state.value.slice(state.selection.end) + this.unit
+			state.value.slice(0, state.selection.start) + symbol + state.value.slice(state.selection.end) + this.suffix
 		return !!nextValue.match(this.pattern)
 	}
 }

--- a/Handler/email.spec.ts
+++ b/Handler/email.spec.ts
@@ -1,0 +1,7 @@
+import { format } from "./index"
+
+describe("email", () => {
+	it("format", () => {
+		expect(format("hello@world.com", "email", { pattern: /.*@.*/ })).toEqual("hello@world.com")
+	})
+})

--- a/Handler/identity-number.spec.ts
+++ b/Handler/identity-number.spec.ts
@@ -1,6 +1,6 @@
 import { Action } from "../Action"
 import { Formatter } from "../Formatter"
-import { get } from "./index"
+import { format, get } from "./index"
 
 describe("identity-number", () => {
 	const handler = get("identity-number") as Formatter
@@ -17,5 +17,8 @@ describe("identity-number", () => {
 		for (const character of "85050512345")
 			result = Action.apply(handler, result, { key: character })
 		expect(result).toMatchObject({ value: "19850505-1234", selection: { start: 13, end: 13 } })
+	})
+	it("format", () => {
+		expect(format("85050512345", "identity-number")).toEqual("19850505-1234")
 	})
 })

--- a/Handler/postal-code.spec.ts
+++ b/Handler/postal-code.spec.ts
@@ -1,6 +1,6 @@
 import { Action } from "../Action"
 import { Formatter } from "../Formatter"
-import { get } from "./index"
+import { format, get } from "./index"
 
 describe("postal-code", () => {
 	const handler = get("postal-code") as Formatter
@@ -29,5 +29,8 @@ describe("postal-code", () => {
 		let result = { value: "123 4", selection: { start: 5, end: 5 } }
 		result = Action.apply(handler, result, { key: "Backspace" })
 		expect(result).toMatchObject({ value: "123", selection: { start: 3, end: 3 } })
+	})
+	it("format", () => {
+		expect(format("12345", "postal-code")).toEqual("123 45")
 	})
 })


### PR DESCRIPTION
* format function now spreads arguments into the get function
  * added tests to make sure the extra spread did not break anything that was using arguments
* removed forced space on durations unit
