### PR TITLE
fix: infinite loop with empty string suffix

### DIFF
--- a/Handler/duration.spec.ts
+++ b/Handler/duration.spec.ts
@@ -12,6 +12,9 @@ describe("duration", () => {
 		const result = Action.apply(handler, { value: "", selection: { start: 0, end: 0 } }, { key: "1" })
 		expect(result).toMatchObject({ value: "1 h", selection: { start: 1, end: 1 } })
 	})
+	it("no unit", () => {
+		expect(format({ hours: 1, minutes: 30 }, "duration", "")).toEqual("1:30")
+	})
 	it("1: + 1 => 1:1", () => {
 		const result = Action.apply(handler, { value: "1:", selection: { start: 2, end: 2 } }, { key: "1" })
 		expect(result).toMatchObject({ value: "1:1 h", selection: { start: 3, end: 3 } })

--- a/StateEditor.ts
+++ b/StateEditor.ts
@@ -76,7 +76,7 @@ export class StateEditor implements Readonly<State> {
 			let s: number
 			// eslint-disable-next-line @typescript-eslint/no-this-alias
 			result = this
-			while ((s = result.value.indexOf(start)) > -1)
+			while (start && (s = result.value.indexOf(start)) > -1)
 				result = result.delete(s, s + start.length)
 		} else
 			result = this.replace(start, end || start + 1, "")


### PR DESCRIPTION
* when StatteEditor.delete() was called with an empty string it got stuck in an infinite while loop.