### PR TITLE
fix: duration toString

### DIFF
--- a/Handler/duration.spec.ts
+++ b/Handler/duration.spec.ts
@@ -23,6 +23,31 @@ describe("duration", () => {
 		expect(handler.format(StateEditor.modify("-,1")).value).toEqual("-0,1")
 		expect(handler.format(StateEditor.modify("-.1")).value).toEqual("-0.1")
 		expect(handler.format(StateEditor.modify("-:1")).value).toEqual("-0:1")
+		expect(handler.format(StateEditor.modify("0:03")).value).toEqual("0:03")
+	})
+	it("smoothly", () => {
+		function smoothlyFormat(value: string) {
+			return handler.format(
+				StateEditor.copy(
+					handler.unformat(
+						StateEditor.copy({
+							value: value,
+							selection: { start: value.length, end: value.length, direction: "none" },
+						})
+					)
+				)
+			)
+		}
+		function smoothlyNewState(value: isoly.TimeSpan) {
+			return smoothlyFormat(handler.toString(value))
+		}
+		expect(smoothlyFormat("0:03").value).toEqual("0:03")
+		expect(smoothlyNewState({ hours: 30 }).value).toEqual("30")
+		expect(smoothlyNewState({ minutes: 30 }).value).toEqual("0:30")
+		expect(smoothlyNewState({ hours: 30, minutes: 30 }).value).toEqual("30:30")
+		expect(smoothlyNewState({ hours: -30, minutes: 30 }).value).toEqual("-29:30")
+		expect(smoothlyNewState({ hours: 30, minutes: -30 }).value).toEqual("29:30")
+		expect(smoothlyNewState({ hours: -30, minutes: -30 }).value).toEqual("-30:30")
 	})
 	it("Key event first key 1", () => {
 		const result = Action.apply(handler, { value: "", selection: { start: 0, end: 0 } }, { key: "1" })
@@ -61,9 +86,9 @@ describe("duration", () => {
 	})
 	it("toString", () => {
 		expect(handler.toString({})).toEqual("")
-		expect(handler.toString({ hours: 25 })).toEqual("25:")
-		expect(handler.toString({ minutes: 30 })).toEqual(":30")
-		expect(handler.toString({ minutes: 3 })).toEqual(":3")
+		expect(handler.toString({ hours: 25 })).toEqual("25")
+		expect(handler.toString({ minutes: 30 })).toEqual("0:30")
+		expect(handler.toString({ minutes: 3 })).toEqual("0:3")
 		expect(handler.toString({ hours: 8, minutes: 5 })).toEqual("8:5")
 	})
 	it("fromString", () => {

--- a/Handler/duration.ts
+++ b/Handler/duration.ts
@@ -22,12 +22,14 @@ class Handler implements Converter<isoly.TimeSpan>, Formatter {
 			const span = isoly.TimeSpan.normalize(data)
 			if (!span.minutes && !span.hours)
 				result = ""
-			else if (this.separator == ":")
-				result = `${!span.hours ? "" : span.hours.toString(10)}:${
-					!span.minutes ? "" : Math.abs(span.minutes).toString(10)
-				}`
+			else if (this.separator != ":")
+				result = (+isoly.TimeSpan.toHours(span).toFixed(2) || "").toString(10)
+			else if (span.hours && !span.minutes)
+				result = span.hours.toString(10)
+			else if (!span.hours && span.minutes)
+				result = `${span.minutes < 0 ? "-" : ""}0:${Math.abs(span.minutes).toString(10)}`
 			else
-				result = (+isoly.TimeSpan.toHours(span).toFixed(2) || "").toString()
+				result = `${span.hours?.toString(10)}:${Math.abs(span.minutes ?? 0).toString(10)}`
 		}
 		return result
 	}


### PR DESCRIPTION
fixes: 
* added smoothly tests that mimics what smoothly does on `componentWillLoad(...)`
* updated `toString(...)` to add 0 hours if span only has minutes
* updated `toString(...)` to exclude `:` if span has no minutes