### PR TITLE
fix: fromString

### DIFF
--- a/Handler/duration.spec.ts
+++ b/Handler/duration.spec.ts
@@ -103,5 +103,6 @@ describe("duration", () => {
 		expect(handler.fromString("-1,5")).toEqual({ hours: -1, minutes: -30 })
 		expect(handler.fromString("1.5")).toEqual({ hours: 1, minutes: 30 })
 		expect(handler.fromString("-1.5")).toEqual({ hours: -1, minutes: -30 })
+		expect(handler.fromString("-1:30")).toEqual({ hours: -1, minutes: -30 })
 	})
 })

--- a/Handler/duration.ts
+++ b/Handler/duration.ts
@@ -46,9 +46,10 @@ class Handler implements Converter<isoly.TimeSpan>, Formatter {
 					hours: parseInt(hours),
 					minutes: parseInt(minutes),
 				}
+				const multiplicand = negative ? -1 : 1
 				result = isoly.TimeSpan.normalize({
-					hours: !Number.isFinite(parsed.hours) ? 0 : parsed.hours,
-					minutes: !Number.isFinite(parsed.minutes) ? 0 : negative ? parsed.minutes * -1 : parsed.minutes,
+					hours: !Number.isFinite(parsed.hours) ? 0 : parsed.hours * multiplicand,
+					minutes: !Number.isFinite(parsed.minutes) ? 0 : parsed.minutes * multiplicand,
 				})
 			} else {
 				const hours = parseFloat(value.replace(",", "."))


### PR DESCRIPTION
fixes: 
* fromString interpreted `-1:30` as `{ hours: 1, minutes: -30}` since only the minutes were multiplied with `-1` if first character was a `-`