### PR TITLE
Differentiate between 0 and undefined percent

### DIFF
--- a/Handler/percent.spec.ts
+++ b/Handler/percent.spec.ts
@@ -1,13 +1,20 @@
 import { Action } from "../Action"
+import { Converter } from "../Converter"
 import { Formatter } from "../Formatter"
 import { StateEditor } from "../StateEditor"
 import { get } from "./index"
 
 describe("percent", () => {
-	const handler = get("percent") as Formatter
+	const handler = get("percent") as Converter<number | unknown> & Formatter
 	it("key event first key", () => {
 		const result = Action.apply(handler, { value: "", selection: { start: 0, end: 0 } }, { key: "1" })
 		expect(result).toMatchObject({ value: "1 %", selection: { start: 1, end: 1 } })
+	})
+	it("key event first key 0", () => {
+		const zeroPressedState = Action.apply(handler, { value: "", selection: { start: 0, end: 0 } }, { key: "0" })
+		expect(zeroPressedState).toMatchObject({ value: "0 %", selection: { start: 1, end: 1 } })
+		const backspaceState = Action.apply(handler, zeroPressedState, { key: "Backspace" })
+		expect(backspaceState).toMatchObject({ value: "", selection: { start: 0, end: 0 } })
 	})
 	it("key event letter", () => {
 		const result = Action.apply(handler, { value: "", selection: { start: 0, end: 0 } }, { key: "a" })
@@ -24,5 +31,19 @@ describe("percent", () => {
 	it("doesn't add suffix on empty", () => {
 		const result = handler.format(StateEditor.copy({ value: "", selection: { start: 0, end: 0 } }))
 		expect(result).toMatchObject({ value: "", selection: { start: 0, end: 0 } })
+	})
+	it("toString", () => {
+		expect(handler.toString(1)).toEqual("100")
+		expect(handler.toString(0.5)).toEqual("50")
+		expect(handler.toString(0.25)).toEqual("25")
+		expect(handler.toString(0)).toEqual("0")
+		expect(handler.toString(undefined)).toEqual("")
+	})
+	it("fromString", () => {
+		expect(handler.fromString("100")).toEqual(1)
+		expect(handler.fromString("50")).toEqual(0.5)
+		expect(handler.fromString("25")).toEqual(0.25)
+		expect(handler.fromString("0")).toEqual(0)
+		expect(handler.fromString("")).toEqual(undefined)
 	})
 })

--- a/Handler/percent.ts
+++ b/Handler/percent.ts
@@ -7,10 +7,11 @@ import { add } from "./base"
 
 class Handler implements Converter<number>, Formatter {
 	toString(data?: number | unknown): string {
-		return data && typeof data == "number" ? (data * 100).toString() : ""
+		return typeof data == "number" ? (data * 100).toString() : ""
 	}
 	fromString(value: string): number | undefined {
-		return typeof value != "string" || !Number.parseFloat(value) ? undefined : Number.parseFloat(value) / 100
+		const parsedFloat = typeof value == "string" ? Number.parseFloat(value) : undefined
+		return typeof parsedFloat == "number" && !Number.isNaN(parsedFloat) ? parsedFloat / 100 : undefined
 	}
 	format(unformatted: StateEditor): Readonly<State> & Settings {
 		return {


### PR DESCRIPTION
I found issues when setting `0` as the initial value in `<smoothly-input type="percent" value={0}>`.
So here is a fix.