### PR TITLE
Fix date format bug.

### DIFF
--- a/Handler/date/dmy.ts
+++ b/Handler/date/dmy.ts
@@ -20,7 +20,7 @@ class Handler extends Base {
 		return isoly.Date.is(result) ? result : undefined
 	}
 	format(unformatted: StateEditor): Readonly<State> & Settings {
-		let result = unformatted
+		let result = unformatted.delete(this.separator)
 		if (result.get(0, 1) > "3")
 			result = result.insert(0, "0")
 		if (result.value.length > 1)

--- a/Handler/date/index.spec.ts
+++ b/Handler/date/index.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { isoly } from "isoly"
 import { Action } from "../../Action"
-import { get } from "../index"
+import { format, get } from "../index"
 
 describe("Date handler", () => {
 	const handlers = { gb: get("date", "en-GB"), us: get("date", "en-US"), standard: get("date") }
@@ -14,5 +15,12 @@ describe("Date handler", () => {
 		for (const character of "1230202012")
 			result = Action.apply(handlers.us!, result, { key: character })
 		expect(result).toMatchObject({ value: "12/30/2020", selection: { start: 10, end: 10 } })
+	})
+	it.only.each([
+		["2024-11-21", "sv-SE", "2024-11-21"],
+		["2024-01-31", "en-GB", "31/01/2024"],
+		["2024-07-04", "en-US", "07/04/2024"],
+	] as [isoly.Date, isoly.Locale, string][])("format", (date, locale, formattedDate) => {
+		expect(format(date, "date", locale)).toEqual(formattedDate)
 	})
 })

--- a/Handler/date/mdy.ts
+++ b/Handler/date/mdy.ts
@@ -20,7 +20,7 @@ class Handler extends Base {
 		return isoly.Date.is(result) ? result : undefined
 	}
 	format(unformatted: StateEditor): Readonly<State> & Settings {
-		let result = unformatted
+		let result = unformatted.delete(this.separator)
 		if (result.get(0, 1) > "1")
 			result = result.insert(0, "0")
 		if (result.value.length > 1)

--- a/Handler/date/ymd.ts
+++ b/Handler/date/ymd.ts
@@ -24,7 +24,7 @@ class Handler extends Base {
 			: 31
 	}
 	format(unformatted: StateEditor): Readonly<State> & Settings {
-		let result = unformatted
+		let result = unformatted.delete(this.separator)
 		if (result.value.length > 3) {
 			result = result.insert(4, this.separator)
 			if (result.get(5, 1) > "1")

--- a/Handler/identity-number.ts
+++ b/Handler/identity-number.ts
@@ -18,7 +18,7 @@ class Handler implements Converter<string>, Formatter {
 		let result = unformatted
 		const year = new Date().getFullYear().toString()
 		if (unformatted.value.length > 1 && unformatted.get(0, 2) != "19" && unformatted.get(0, 2) != "20")
-			result = result.prepend(unformatted.get(0, 2) > year.substr(2, 2) ? "19" : "20")
+			result = result.prepend(unformatted.get(0, 2) > year.substring(2, 4) ? "19" : "20")
 		if (result.value.length >= 8)
 			result = result.insert(8, "-")
 		return {

--- a/StateEditor.ts
+++ b/StateEditor.ts
@@ -10,7 +10,7 @@ export class StateEditor implements Readonly<State> {
 	}
 
 	get(index: number, length = 1): string {
-		return this.value.substr(index, length)
+		return this.value.substring(index, index + length)
 	}
 	is(index: number, ...character: string[]) {
 		const c = this.get(index)


### PR DESCRIPTION
Found that the `format` function was not working for dates. 
The Handler.format in (ymd, dmy, mdy) function assumes no separators included in `state.value`.

Also changed from depricated `.substr` to `.substring()`

## Bug
![Screenshot from 2024-07-30 10-21-45](https://github.com/user-attachments/assets/4b7abc17-3566-4e12-8709-1bfa407f9b6b)
![Screenshot from 2024-07-30 10-20-52](https://github.com/user-attachments/assets/44b647a1-e8b3-43eb-a12d-0e35f60af1af)
![Screenshot from 2024-07-30 10-18-50](https://github.com/user-attachments/assets/862375fa-ddec-408d-82c7-9dac9f6cd632)
