### PR TITLE
Only use input types that support selection.

### DIFF
--- a/Handler/email.ts
+++ b/Handler/email.ts
@@ -14,7 +14,7 @@ class Handler implements Converter<string>, Formatter {
 		return typeof value == "string" && !!value ? value : undefined
 	}
 	format(unformatted: StateEditor): Readonly<State> & Settings {
-		return { ...unformatted, ...this.settings, type: "text", autocomplete: "email" }
+		return { ...unformatted, ...this.settings, type: "text", inputmode: "email", autocomplete: "email" }
 	}
 	unformat(formatted: StateEditor): Readonly<State> {
 		return formatted

--- a/Handler/email.ts
+++ b/Handler/email.ts
@@ -14,7 +14,7 @@ class Handler implements Converter<string>, Formatter {
 		return typeof value == "string" && !!value ? value : undefined
 	}
 	format(unformatted: StateEditor): Readonly<State> & Settings {
-		return { ...unformatted, ...this.settings, type: "email", autocomplete: "email" }
+		return { ...unformatted, ...this.settings, type: "text", autocomplete: "email" }
 	}
 	unformat(formatted: StateEditor): Readonly<State> {
 		return formatted

--- a/Handler/integer.ts
+++ b/Handler/integer.ts
@@ -16,7 +16,7 @@ class Handler implements Converter<number>, Formatter {
 	format(unformatted: StateEditor): Readonly<State> & Settings {
 		return {
 			...unformatted,
-			type: "number",
+			type: "tel",
 			length: [3, undefined],
 			pattern: /^[0-9]+$/,
 		}

--- a/Handler/integer.ts
+++ b/Handler/integer.ts
@@ -16,7 +16,8 @@ class Handler implements Converter<number>, Formatter {
 	format(unformatted: StateEditor): Readonly<State> & Settings {
 		return {
 			...unformatted,
-			type: "tel",
+			type: "text",
+			inputmode: "numeric",
 			length: [3, undefined],
 			pattern: /^[0-9]+$/,
 		}

--- a/Settings.ts
+++ b/Settings.ts
@@ -75,6 +75,7 @@ export interface Settings {
 		| "impp"
 		| "url"
 		| "photo"
+	readonly inputmode?: "none" | "text" | "decimal" | "numeric" | "tel" | "search" | "email" | "url"
 	readonly length?: [number | undefined, number | undefined]
 	readonly pattern?: RegExp
 	readonly classes?: string[]


### PR DESCRIPTION
## Bug
Navigating a text field with with tidily.Type `integer` or `email` does not work.
This is because `<input type="number">` and `<input type="email">` do not support selection variables and methods, such as:  `input.selectionStart` or `input.setSelectionRange`

And unfortunately I have not other was to fix this for now other then changing the `input.type` attribute.

sources:
https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number)
https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)

![image](https://github.com/user-attachments/assets/1db26b23-0dad-4505-ac6b-bd4933a12051)
