### PR TITLE
Add toInteger for price

### DIFF
--- a/Handler/base.ts
+++ b/Handler/base.ts
@@ -4,6 +4,7 @@ import { DateFormat } from "../DateFormat"
 import { Formatter } from "../Formatter"
 import { StateEditor } from "../StateEditor"
 import { Type } from "../Type"
+import { PriceOptions } from "./price"
 
 const handlers: { [type: string]: ((argument?: any[]) => Converter<any> & Formatter) | undefined } = {}
 export function add(type: Type, create: (argument?: any[]) => Converter<any> & Formatter): void {
@@ -21,7 +22,7 @@ export function get(
 	type: "identity-number" | "phone" | "postal-code",
 	country?: isoly.CountryCode.Alpha2
 ): (Converter<string> & Formatter) | undefined
-export function get(type: "price", currency: isoly.Currency): (Converter<number> & Formatter) | undefined
+export function get(type: "price", currency: isoly.Currency | PriceOptions): (Converter<number> & Formatter) | undefined
 export function get(type: "date", format?: DateFormat | isoly.Locale): (Converter<isoly.Date> & Formatter) | undefined
 export function get<T>(type: Type, ...argument: any[]): (Converter<T> & Formatter) | undefined
 export function get<T>(type: Type, ...argument: any[]): (Converter<T> & Formatter) | undefined {
@@ -39,7 +40,7 @@ export function format(
 	type: "identity-number" | "phone" | "postal-code",
 	country?: isoly.CountryCode.Alpha2
 ): string
-export function format(data: number, type: "price", currency: isoly.Currency): string
+export function format(data: number, type: "price", currency: isoly.Currency | PriceOptions): string
 export function format(data: any, type: Type, ...argument: any[]): string
 export function format(data: any, type: Type, ...argument: any[]): string {
 	const handler = get(type, ...argument)


### PR DESCRIPTION
To deprecate `<smoothly-display-amount />` and replace with `<smoothly-display type="price' />`, all aspects of the old display-amount should be covered.

So this PR adds ability to set `toInteger` in price handler, so this can be set on both display and input in smoothly.

Display:
![image](https://github.com/user-attachments/assets/17a8b156-5238-454d-84a3-acf21fdc1316)

Input:
![image](https://github.com/user-attachments/assets/af2215da-2757-455c-bc29-f1c5d5f119fc)
