### PR TITLE
Change formatting for 14 digit unknown card numbers.

### DIFF
--- a/Handler/card-number.spec.ts
+++ b/Handler/card-number.spec.ts
@@ -15,6 +15,18 @@ describe("card-number", () => {
 			result = Action.apply(handler, result, { key: character })
 		expect(result).toMatchObject({ value: "4242 4242", selection: { start: 9, end: 9 } })
 	})
+	it("key event unknown 13,14,15,16 digit numbers", () => {
+		let result = { value: "", selection: { start: 0, end: 0 } }
+		for (const character of "1111120000333")
+			result = Action.apply(handler, result, { key: character })
+		expect(result).toMatchObject({ value: "1111 1200 0033 3", selection: { start: 16, end: 16 } }) // 13 digits
+		result = Action.apply(handler, result, { key: "3" })
+		expect(result).toMatchObject({ value: "1111 120000 3333", selection: { start: 16, end: 16 } }) // 14 digits
+		result = Action.apply(handler, result, { key: "4" })
+		expect(result).toMatchObject({ value: "1111 1200 0033 334", selection: { start: 18, end: 18 } }) // 15 digits
+		// result = Action.apply(handler, result, { key: "5" })
+		// expect(result).toMatchObject({ value: "1111 1200 0033 3345", selection: { start: 19, end: 19 } }) // 16 digits
+	})
 	it("key event full visa number", () => {
 		let result = { value: "", selection: { start: 0, end: 0 } }
 		for (const character of "4242424242424242")

--- a/Handler/card-number.spec.ts
+++ b/Handler/card-number.spec.ts
@@ -24,8 +24,10 @@ describe("card-number", () => {
 		expect(result).toMatchObject({ value: "1111 120000 3333", selection: { start: 16, end: 16 } }) // 14 digits
 		result = Action.apply(handler, result, { key: "4" })
 		expect(result).toMatchObject({ value: "1111 1200 0033 334", selection: { start: 18, end: 18 } }) // 15 digits
-		// result = Action.apply(handler, result, { key: "5" })
-		// expect(result).toMatchObject({ value: "1111 1200 0033 3345", selection: { start: 19, end: 19 } }) // 16 digits
+		result = Action.apply(handler, result, { key: "5" })
+		expect(result).toMatchObject({ value: "1111 1200 0033 3345", selection: { start: 19, end: 19 } }) // 16 digits
+		result = Action.apply(handler, result, { key: "6" })
+		expect(result).toMatchObject({ value: "1111 1200 0033 3345", selection: { start: 19, end: 19 } }) // 17 digits - too long
 	})
 	it("key event full visa number", () => {
 		let result = { value: "", selection: { start: 0, end: 0 } }

--- a/Handler/card-number.spec.ts
+++ b/Handler/card-number.spec.ts
@@ -1,7 +1,7 @@
 import { Action } from "../Action"
 import { Converter } from "../Converter"
 import { Formatter } from "../Formatter"
-import { get } from "./index"
+import { format, get } from "./index"
 
 describe("card-number", () => {
 	const handler = get("card-number") as Converter<"string" | unknown> & Formatter
@@ -28,6 +28,9 @@ describe("card-number", () => {
 		expect(result).toMatchObject({ value: "1111 1200 0033 3345", selection: { start: 19, end: 19 } }) // 16 digits
 		result = Action.apply(handler, result, { key: "6" })
 		expect(result).toMatchObject({ value: "1111 1200 0033 3345", selection: { start: 19, end: 19 } }) // 17 digits - too long
+	})
+	it("format 14 digit number", () => {
+		expect(format("11111200003333", "card-number")).toEqual("1111 120000 3333")
 	})
 	it("key event full visa number", () => {
 		let result = { value: "", selection: { start: 0, end: 0 } }

--- a/Handler/card-number.ts
+++ b/Handler/card-number.ts
@@ -48,12 +48,22 @@ interface CardIssuer {
 }
 function getIssuer(value: string): CardIssuer & { name: string } {
 	let result: CardIssuer & { name: string } = defaultIssuer
+	if (default14DigitIssuer.identification.test(value))
+		result = default14DigitIssuer
 	for (const key in issuers)
 		if (Object.prototype.hasOwnProperty.call(issuers, key) && issuers[key].identification.test(value)) {
 			result = { ...defaultIssuer, name: key, ...issuers[key] }
 			break
 		}
 	return result
+}
+const default14DigitIssuer: CardIssuer = {
+	name: "unknown14DigitIssuer",
+	verification: /^\d{4}\s\d{6}\s\d{4}$/,
+	spaceIndexes: [4, 10],
+	identification: /^\d{14}$/,
+	length: [14, 16, 16],
+	icon: "generic",
 }
 const defaultIssuer: CardIssuer = {
 	name: "unknown",

--- a/Handler/card-number.ts
+++ b/Handler/card-number.ts
@@ -47,23 +47,16 @@ interface CardIssuer {
 	icon: string
 }
 function getIssuer(value: string): CardIssuer & { name: string } {
-	let result: CardIssuer & { name: string } = defaultIssuer
-	if (default14DigitIssuer.identification.test(value))
-		result = default14DigitIssuer
+	let result: CardIssuer & { name: string } = {
+		...defaultIssuer,
+		spaceIndexes: value.length == 14 ? [4, 10] : defaultIssuer.spaceIndexes,
+	}
 	for (const key in issuers)
 		if (Object.prototype.hasOwnProperty.call(issuers, key) && issuers[key].identification.test(value)) {
 			result = { ...defaultIssuer, name: key, ...issuers[key] }
 			break
 		}
 	return result
-}
-const default14DigitIssuer: CardIssuer = {
-	name: "unknown14DigitIssuer",
-	verification: /^\d{4}\s\d{6}\s\d{4}$/,
-	spaceIndexes: [4, 10],
-	identification: /^\d{14}$/,
-	length: [14, 16, 16],
-	icon: "generic",
 }
 const defaultIssuer: CardIssuer = {
 	name: "unknown",


### PR DESCRIPTION
This is needed to format 14 digit test cards to look like correct.

E.g. `1111 222333 4444`

[Screencast from 2024-10-28 16:45:36.webm](https://github.com/user-attachments/assets/53e76161-a131-4053-af84-4b70d7e2d9e1)

