### PR TITLE
Add pad length option for integer

### DIFF
--- a/Handler/IntegerOptions.ts
+++ b/Handler/IntegerOptions.ts
@@ -1,4 +1,5 @@
 export interface IntegerOptions {
 	min?: number
 	max?: number
+	padToLength?: number
 }

--- a/Handler/IntegerOptions.ts
+++ b/Handler/IntegerOptions.ts
@@ -1,5 +1,5 @@
 export interface IntegerOptions {
 	min?: number
 	max?: number
-	padToLength?: number
+	pad?: number
 }

--- a/Handler/integer.spec.ts
+++ b/Handler/integer.spec.ts
@@ -69,4 +69,21 @@ describe("percent", () => {
 			expect(tidily.format(data, "integer", { min, max })).toEqual(formattedValue)
 		}
 	)
+	it.each([
+		["15", undefined, "15"],
+		["15", 3, "015"],
+		["8", 3, "008"],
+		["15", 0, "15"],
+		["5", 2, "05"],
+		["0", 2, "00"],
+		["", 2, ""],
+	])(
+		"padToLength options %s.padToLength(%s) -.> %s",
+		(data: string | undefined, padToLength: number | undefined, formattedValue: string) => {
+			const handler = tidily.get("integer", { padToLength }) as tidily.Converter<"string" | unknown> & tidily.Formatter
+			const partialFormattedState = handler.partialFormat(tidily.StateEditor.modify(data))
+			expect(partialFormattedState.value).toEqual(data)
+			expect(tidily.format(data, "integer", { padToLength })).toEqual(formattedValue)
+		}
+	)
 })

--- a/Handler/integer.spec.ts
+++ b/Handler/integer.spec.ts
@@ -77,13 +77,10 @@ describe("percent", () => {
 		["5", 2, "05"],
 		["0", 2, "00"],
 		["", 2, ""],
-	])(
-		"padToLength options %s.padToLength(%s) -.> %s",
-		(data: string | undefined, padToLength: number | undefined, formattedValue: string) => {
-			const handler = tidily.get("integer", { padToLength }) as tidily.Converter<"string" | unknown> & tidily.Formatter
-			const partialFormattedState = handler.partialFormat(tidily.StateEditor.modify(data))
-			expect(partialFormattedState.value).toEqual(data)
-			expect(tidily.format(data, "integer", { padToLength })).toEqual(formattedValue)
-		}
-	)
+	])("pad options %s.pad(%s) -.> %s", (data: string, pad: number | undefined, formattedValue: string) => {
+		const handler = tidily.get("integer", { pad }) as tidily.Converter<"string" | unknown> & tidily.Formatter
+		const partialFormattedState = handler.partialFormat(tidily.StateEditor.modify(data))
+		expect(partialFormattedState.value).toEqual(data)
+		expect(tidily.format(data, "integer", { pad })).toEqual(formattedValue)
+	})
 })

--- a/Handler/integer.ts
+++ b/Handler/integer.ts
@@ -9,9 +9,11 @@ import { IntegerOptions } from "./IntegerOptions"
 class Handler implements Converter<number>, Formatter {
 	readonly min: number | undefined
 	readonly max: number | undefined
+	readonly padToLength: number | undefined
 	constructor(options: IntegerOptions) {
 		this.min = options.min
 		this.max = options.max
+		this.padToLength = options.padToLength
 	}
 	toString(data?: number | unknown): string {
 		return typeof data == "number" ? data.toString() : ""
@@ -32,17 +34,18 @@ class Handler implements Converter<number>, Formatter {
 	}
 	format(unformatted: StateEditor): Readonly<State> & Settings {
 		const result = this.partialFormat(unformatted)
-		const value = this.fromString(result.value)
+		const number = this.fromString(result.value)
+		const value =
+			number == undefined
+				? result.value
+				: this.min != undefined && number < this.min
+				? this.toString(this.min)
+				: this.max != undefined && number > this.max
+				? this.toString(this.max)
+				: result.value
 		return {
 			...result,
-			value:
-				value == undefined
-					? result.value
-					: this.min != undefined && value < this.min
-					? this.toString(this.min)
-					: this.max != undefined && value > this.max
-					? this.toString(this.max)
-					: result.value,
+			value: typeof this.padToLength == "number" && value ? value.padStart(this.padToLength, "0") : value,
 		}
 	}
 	unformat(formatted: StateEditor): Readonly<State> {

--- a/Handler/integer.ts
+++ b/Handler/integer.ts
@@ -9,11 +9,11 @@ import { IntegerOptions } from "./IntegerOptions"
 class Handler implements Converter<number>, Formatter {
 	readonly min: number | undefined
 	readonly max: number | undefined
-	readonly padToLength: number | undefined
+	readonly pad: number | undefined
 	constructor(options: IntegerOptions) {
 		this.min = options.min
 		this.max = options.max
-		this.padToLength = options.padToLength
+		this.pad = options.pad
 	}
 	toString(data?: number | unknown): string {
 		return typeof data == "number" ? data.toString() : ""
@@ -45,7 +45,7 @@ class Handler implements Converter<number>, Formatter {
 				: result.value
 		return {
 			...result,
-			value: typeof this.padToLength == "number" && value ? value.padStart(this.padToLength, "0") : value,
+			value: typeof this.pad == "number" && value ? value.padStart(this.pad, "0") : value,
 		}
 	}
 	unformat(formatted: StateEditor): Readonly<State> {


### PR DESCRIPTION
Needed to pad hour and minute in date-time input.
Other names suggestions then `padToLength` are welcome.

[Screencast from 2025-03-27 16:08:01.webm](https://github.com/user-attachments/assets/f3922348-fb2f-4aa0-881c-26bbd4d674b6)
